### PR TITLE
Add example Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,28 @@ docker run --name influxdb-1.8 -p 8086:8086 influxdb:1.8
 docker run --name influxdb-2 -p 8086:8086 quay.io/influxdb/influxdb:v2.0.3
 
 ```
+
+---
+
+## Importing Example Grafana Dashboard
+
+To help you get started with visualizing your data in Grafana, we have provided an example Grafana dashboard JSON file. You can find this file in the repository as `grafana-dashboard-example.json`.
+
+### Steps to Import the Example Dashboard
+
+1. Open your Grafana instance and log in.
+2. Click on the "+" icon in the left sidebar and select "Import".
+3. In the "Import via panel json" section, click on "Upload JSON file".
+4. Select the `grafana-dashboard-example.json` file from the repository.
+5. Click on "Load".
+6. In the "Options" section, select the InfluxDB data source you have configured.
+7. Click on "Import".
+
+You should now see the example dashboard with panels for visualizing the data pushed to InfluxDB.
+
+### Customizing the Dashboard
+
+Feel free to customize the example dashboard to suit your needs. You can add more panels, change the queries, and adjust the visualizations as required.
+
+For more information on how to use Grafana, refer to the [Grafana documentation](https://grafana.com/docs/).
+

--- a/grafana-dashboard-example.json
+++ b/grafana-dashboard-example.json
@@ -1,0 +1,139 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "Newman InfluxDB Dashboard",
+    "tags": [],
+    "timezone": "browser",
+    "schemaVersion": 16,
+    "version": 0,
+    "refresh": "5s",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "Response Time",
+        "gridPos": {
+          "x": 0,
+          "y": 0,
+          "w": 24,
+          "h": 9
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "measurement": "api_results",
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$__interval"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "response_time"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                }
+              ]
+            ],
+            "resultFormat": "time_series",
+            "orderByTime": "ASC",
+            "alias": "Response Time"
+          }
+        ],
+        "xaxis": {
+          "mode": "time",
+          "show": true
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "show": true
+          },
+          {
+            "show": true
+          }
+        ]
+      },
+      {
+        "type": "table",
+        "title": "Test Results",
+        "gridPos": {
+          "x": 0,
+          "y": 9,
+          "w": 24,
+          "h": 9
+        },
+        "targets": [
+          {
+            "refId": "A",
+            "measurement": "api_results",
+            "groupBy": [],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "test_status"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "request_name"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "response_time"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "response_size"
+                  ]
+                }
+              ]
+            ],
+            "resultFormat": "table",
+            "orderByTime": "ASC",
+            "alias": "Test Results"
+          }
+        ],
+        "columns": [
+          {
+            "text": "Request Name",
+            "value": "request_name"
+          },
+          {
+            "text": "Status",
+            "value": "test_status"
+          },
+          {
+            "text": "Response Time",
+            "value": "response_time"
+          },
+          {
+            "text": "Response Size",
+            "value": "response_size"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Related to #40

Add an example Grafana dashboard JSON file and update the README.md with instructions on how to import it.

* **grafana-dashboard-example.json**
  - Add a JSON file containing an example Grafana dashboard configuration with panels for visualizing response time and test results.

* **README.md**
  - Add a section on how to import the example Grafana dashboard.
  - Provide instructions on how to visualize the data pushed to InfluxDB using the example dashboard.
  - Include steps to customize the dashboard as needed.
