### PR TITLE
Fix TypeError for undefined response properties in InfluxDBReporter

### DIFF
--- a/src/influxdb-reporter.js
+++ b/src/influxdb-reporter.js
@@ -87,6 +87,11 @@ class InfluxDBReporter {
 
     console.log(`[${this.context.currentItem.index}] Running ${item.name}`);
 
+    if (!args.response) {
+      console.log(`[-] ERROR: Response is undefined for request ${item.name}`);
+      return;
+    }
+
     const data = {
       collection_name: this.options.collection.name, 
       id: this.context.identifier,


### PR DESCRIPTION
Related to #41

Add a check to handle undefined response properties in `InfluxDBReporter.request` function.

* Add a check to ensure `args.response` is defined before accessing its properties.
* Log an error message and skip the current request if `args.response` is undefined.

